### PR TITLE
refactor: change the recievers argument to 'emailRecipients'

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,20 +42,21 @@ After all the configuration steps please make sure the folder tree looks like th
 ├─ cxsast_consolidated_report_v{version}_win_x64.exe
 ```
 
-## Utilization
+# Utilization
 
 In order to use the **CxSAST Consolidated Report** you just need to run the executable `cxsast_consolidated_report_v{latestVersion}_win_x64.exe` passing the following mandatory arguments prefixed with `--`
 
 ### Available Arguments
 
-| Option         | Type   | Required | Description                                                                                                                                                                                                           |
-| -------------- | ------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| projectPattern | String | required | Should be a string to match project's name beginning. This will be used by [str.startsWith()](https://www.w3schools.com/jsref/jsref_startswith.asp) node function to select all the projects started with this string |
-| appName        | String | required | The name of the app that will be displayed on the report                                                                                                                                                              |
-| emailSubject   | String | required | The email subject of the report                                                                                                                                                                                       |
+| Option          | Type   | Required | Description                                                                                                                                                                                                           |
+| --------------- | ------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| projectPattern  | String | required | Should be a string to match project's name beginning. This will be used by [str.startsWith()](https://www.w3schools.com/jsref/jsref_startswith.asp) node function to select all the projects started with this string |
+| appName         | String | required | The name of the app that will be displayed on the report                                                                                                                                                              |
+| emailSubject    | String | required | The email subject of the report                                                                                                                                                                                       |
+| emailRecipients | String | required | A list of comma separated emails of the recipients of the report                                                                                                                                                       |
 
-So the full command should look like this:
+So the full command will look like this:
 
 ```
-.\cxsast_consolidated_report_v{latestVersion}_win_x64.exe --projectPattern "Test project" --appName "Test Project Reports" --emailSubject "Emails Test Subject" --receivers "receiver1@mail.com, receiver2@mail.com"
+.\cxsast_consolidated_report_v{latestVersion}_win_x64.exe --projectPattern "Test project" --appName "Test Project Reports" --emailSubject "Emails Test Subject" --emailRecipients "email1@mail.com, email2@mail.com"
 ```

--- a/docs/UTILIZATION.md
+++ b/docs/UTILIZATION.md
@@ -4,15 +4,15 @@ In order to use the **CxSAST Consolidated Report** you just need to run the exec
 
 ### Available Arguments
 
-| Option         | Type   | Required | Description                                                                        |
-| -------------- | ------ | -------- | ---------------------------------------------------------------------------------- |
-| projectPattern | String | required | Should be a string to match project's name beginning. This will be used by [str.startsWith()](https://www.w3schools.com/jsref/jsref_startswith.asp) node function to select all the projects started with this string|
-| appName        | String | required | The name of the app that will be displayed on the report                           |
-| emailSubject   | String | required | The email subject of the report                                                    |
-| recievers      | String | required | A list of comma separated emails of the recievers of the report                    |
+| Option          | Type   | Required | Description                                                                                                                                                                                                           |
+| --------------- | ------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| projectPattern  | String | required | Should be a string to match project's name beginning. This will be used by [str.startsWith()](https://www.w3schools.com/jsref/jsref_startswith.asp) node function to select all the projects started with this string |
+| appName         | String | required | The name of the app that will be displayed on the report                                                                                                                                                              |
+| emailSubject    | String | required | The email subject of the report                                                                                                                                                                                       |
+| emailRecipients | String | required | A list of comma separated emails of the recipients of the report                                                                                                                                                       |
 
 So the full command will look like this:
 
-```shell
-.\cxsast_consolidated_report_v{latestVersion}_win_x64.exe --projectPattern "Test project" --appName "Test Project Reports" --emailSubject "Emails Test Subject" --recievers "reciever1@mail.com, reciever1@mail.com"
+```
+.\cxsast_consolidated_report_v{latestVersion}_win_x64.exe --projectPattern "Test project" --appName "Test Project Reports" --emailSubject "Emails Test Subject" --emailRecipients "email1@mail.com, email2@mail.com"
 ```

--- a/source/index.ts
+++ b/source/index.ts
@@ -24,7 +24,7 @@ const main = async () => {
             appName: String(args.appName),
         });
 
-        EmailService.sendEmail(compiledTemplate, String(args.emailSubject), String(args.recievers), String(args.appName));
+        EmailService.sendEmail(compiledTemplate, String(args.emailSubject), String(args.emailRecipients), String(args.appName));
     } catch (error) {
         handleError(error);
     }

--- a/source/services/emailService.ts
+++ b/source/services/emailService.ts
@@ -13,12 +13,12 @@ const transporter = nodemailer.createTransport({
     },
 });
 
-const sendEmail = (html: any, subject: string, recievers: string, appName: string) => {
+const sendEmail = (html: any, subject: string, emailRecipients: string, appName: string) => {
     log.info('Sending Email(s)...');
 
     const opts = {
         from: cfg.sender,
-        to: recievers,
+        to: emailRecipients,
         subject,
         html,
     };

--- a/source/utils/argumentsValidator.ts
+++ b/source/utils/argumentsValidator.ts
@@ -2,15 +2,15 @@ import { string, object, array } from 'yup';
 import { handleError } from '../utils';
 
 const validateArgs = (args: any) => {
-    if (args.recievers) {
-        args.recievers = args.recievers.split(',').map((email: string) => email.trim());
+    if (args.emailRecipients) {
+        args.emailRecipients = args.emailRecipients.split(',').map((email: string) => email.trim());
     }
 
     const schema = object().shape({
         projectPattern: string().required(),
         appName: string().required(),
         emailSubject: string().required(),
-        recievers: array()
+        emailRecipients: array()
             .of(string().email())
             .required(),
     });


### PR DESCRIPTION
Changed the `recievers` argument to `emailRecipients` because it was a typo and doesn't make sense.
The `emailRecipients` argument should be used instead from now on.